### PR TITLE
Add Memory Usage Display to Titlebar

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -767,7 +767,7 @@ ipcMain.handle('system:get-info', () => {
     second: '2-digit'
   });
   
-  return { time, cpuUsage: Math.round(totalCpuPercent * 10) / 10 };
+  return { time, cpuUsage: Math.round(totalCpuPercent * 10) / 10, memoryUsage: Math.round(process.memoryUsage().rss / 1024 / 1024) };
 });
 
 // OSC config handlers

--- a/app/src/renderer/App.css
+++ b/app/src/renderer/App.css
@@ -234,6 +234,16 @@
   text-align: right;
 }
 
+.titlebar-info .mem-label {
+  margin-left: 4px;
+}
+
+.titlebar-info .mem-value {
+  font-variant-numeric: tabular-nums;
+  min-width: 42px;
+  text-align: right;
+}
+
 .system-info {
   position: absolute;
   top: 4px;

--- a/app/src/renderer/App.tsx
+++ b/app/src/renderer/App.tsx
@@ -71,7 +71,7 @@ const App: React.FC = () => {
 
   const [downloadProgress, setDownloadProgress] = useState<Map<string, string>>(new Map());
   const [notification, setNotification] = useState<string | null>(null);
-  const [systemInfo, setSystemInfo] = useState<{ time: string; cpuUsage: number }>({ time: '--:--:--', cpuUsage: 0 });
+  const [systemInfo, setSystemInfo] = useState<{ time: string; cpuUsage: number; memoryUsage: number }>({ time: '--:--:--', cpuUsage: 0, memoryUsage: 0 });
   const isLoadingTrackRef = useRef(false);
   const [recordingStatus, setRecordingStatus] = useState<RecordingStatus>({ state: 'idle' });
   const recordingStatusRef = useRef(recordingStatus);
@@ -598,6 +598,9 @@ const App: React.FC = () => {
             ></div>
           </div>
           <span className="cpu-value">{systemInfo.cpuUsage.toFixed(1)}%</span>
+          <div className="titlebar-separator"></div>
+          <span className="mem-label">MEM</span>
+          <span className="mem-value">{systemInfo.memoryUsage}MB</span>
           <div className="titlebar-separator"></div>
           <span className="time">{systemInfo.time}</span>
         </div>

--- a/app/src/types/electron-api.d.ts
+++ b/app/src/types/electron-api.d.ts
@@ -55,7 +55,7 @@ export interface ElectronAPI {
   librarySetLikedFilter: (enabled: boolean) => Promise<void>;
   libraryToggleLikedFilter: () => Promise<void>;
   showTrackContextMenu: (track: AudioInfo) => void;
-  getSystemInfo: () => Promise<{ time: string; cpuUsage: number }>;
+  getSystemInfo: () => Promise<{ time: string; cpuUsage: number; memoryUsage: number }>;
   onLibraryStateChanged: (callback: (state: LibraryState) => void) => () => void;
   onDownloadProgressChanged: (callback: (progress: Map<string, string>) => void) => () => void;
   onLibrarySyncStarted: (callback: (data) => void) => () => void;


### PR DESCRIPTION
Display memory usage in the titlebar similar to CPU usage.

## Changes
- Update getSystemInfo API to include memoryUsage (MB)
- Display memory usage as 'MEM [value]MB' in titlebar next to CPU
- Style similar to CPU display but without progress bar
- Update every 1 second with system info

## Testing
- Verified display in titlebar
- Memory usage updates correctly during app usage