### PR TITLE
fix(audio): enable cpal backend for web-audio-api

### DIFF
--- a/packages/audio/Cargo.toml
+++ b/packages/audio/Cargo.toml
@@ -18,7 +18,7 @@ soundtouch = { version = "0.5", default-features = false }
 thread-priority = "1.2"
 rustfft = "6.2"
 crossbeam-channel = "0.5"
-web-audio-api = { version = "1.2", default-features = false }
+web-audio-api = { version = "1.2", default-features = false, features = ["cpal"] }
 
 # Audio decoding
 symphonia = { version = "0.5", features = ["mp3"] }


### PR DESCRIPTION
Closes #20

`web-audio-api` was configured with `default-features = false` but no backend feature, so the output context could fail to initialize at runtime with a "No audio backend available" panic.

This PR enables the `cpal` backend explicitly in `packages/audio/Cargo.toml` so the Web Audio output graph can initialize reliably.

Validation:
- `cargo check` in `packages/audio`
