### PR TITLE
Phase 4: decouple Electron shell boundaries for Rust-first host

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -670,7 +670,7 @@ function handleWaveformChunk(trackId: string, chunkIndex: number, totalChunks: n
     buffer.compactChunks[chunkIndex] = chunk;
   }
   nativeWaveformBuffers.set(trackId, buffer);
-  sendToRenderer('waveform-chunk', { trackId, chunkIndex, totalChunks, chunk });
+  ipcHost.send(IPC_EVENTS.waveformChunk, { trackId, chunkIndex, totalChunks, chunk });
 }
 
 function handleWaveformComplete(trackId: string, totalFrames: number) {
@@ -702,7 +702,7 @@ function handleWaveformComplete(trackId: string, totalFrames: number) {
 
     nativeWaveformBuffers.delete(trackId);
   }
-  sendToRenderer('waveform-complete', { trackId, totalFrames });
+  ipcHost.send(IPC_EVENTS.waveformComplete, { trackId, totalFrames });
 }
 
 async function emitWaveform(trackId: string, waveformData: Float32Array | number[]) {
@@ -791,7 +791,7 @@ async function loadTrackToDeck(track: Track, deck: 1 | 2) {
   if (structure) {
     trackStructureMap.set(track.id, structure);
     pushNativeDeckMarkers();
-    sendToRenderer('track-structure', { trackId: track.id, deck, structure });
+    ipcHost.send(IPC_EVENTS.trackStructure, { trackId: track.id, deck, structure });
   }
 }
 
@@ -1238,7 +1238,7 @@ const startNativeUIPolling = () => {
           };
           void loadTrackToDeck(track, deck).catch((error) => {
             const message = error instanceof Error ? error.message : String(error);
-            sendToRenderer('notification', `Audio Error: ${message}`);
+            ipcHost.send(IPC_EVENTS.notification, `Audio Error: ${message}`);
           });
           break;
         }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -3,18 +3,11 @@ import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { createRequire } from 'node:module';
 import started from 'electron-squirrel-startup';
-import Store from 'electron-store';
-// Local minimal typed interface to avoid (any) casts while TS 4.5 cannot see inherited methods.
-interface AppStoreSchema { osc: OSCConfig; audio: AudioConfig; recording: RecordingConfig }
-interface AppStore {
-  get(key: 'osc'): OSCConfig;
-  get(key: 'audio'): AudioConfig;
-  get(key: 'recording'): RecordingConfig;
-  set(key: 'osc', value: OSCConfig): void;
-  set(key: 'audio', value: AudioConfig): void;
-  set(key: 'recording', value: RecordingConfig): void;
-}
-type AppPathKey = Parameters<typeof app.getPath>[0];
+import { IPC_CHANNELS, IPC_EVENTS } from './main/ipc-contract';
+import { createElectronIpcHost } from './main/host/electron-ipc-host';
+import { createElectronShellHost } from './main/host/shell-host';
+import { createAppSettingsStore } from './main/settings/app-settings-store';
+import { registerRuntimeLifecycle } from './main/runtime/lifecycle-bootstrap';
 
 import type {
   AudioEngineState,
@@ -114,81 +107,20 @@ declare const PREFERENCES_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const PREFERENCES_WINDOW_VITE_NAME: string;
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
+const shellHost = createElectronShellHost({ app, BrowserWindow, Menu });
+
 if (started) {
-  app.quit();
+  shellHost.quit();
 }
 
-const defaultRecordingDirectory = path.join(app.getPath('music' as AppPathKey), 'Sujay Recordings');
+const defaultRecordingDirectory = path.join(shellHost.getPath('music'), 'Sujay Recordings');
 const defaultRecordingConfig: RecordingConfig = {
   directory: defaultRecordingDirectory,
   autoCreateDirectory: true,
   namingStrategy: 'timestamp',
   format: 'wav',
 };
-
-// Initialize electron-store with schema
-const storeRaw = new Store<AppStoreSchema>({
-  defaults: {
-    osc: {
-      enabled: false,
-      host: '127.0.0.1',
-      port: 9000,
-    },
-    audio: {
-      mainChannels: [0, 1],
-      cueChannels: [null, null],
-    },
-    recording: defaultRecordingConfig,
-  },
-  schema: {
-    osc: {
-      type: 'object',
-      properties: {
-        enabled: { type: 'boolean' },
-        host: { type: 'string' },
-        port: { type: 'number', minimum: 1, maximum: 65535 },
-      },
-      required: ['enabled', 'host', 'port'],
-    },
-    audio: {
-      type: 'object',
-      properties: {
-        deviceId: { type: ['string', 'null'] },
-        mainChannels: { type: 'array', items: { type: ['number', 'null'] }, minItems: 2, maxItems: 2 },
-        cueChannels: { type: 'array', items: { type: ['number', 'null'] }, minItems: 2, maxItems: 2 },
-      },
-      required: ['mainChannels', 'cueChannels'],
-    },
-    recording: {
-      type: 'object',
-      properties: {
-        directory: { type: 'string' },
-        autoCreateDirectory: { type: 'boolean' },
-        namingStrategy: { type: 'string', enum: ['timestamp', 'sequential'] },
-        format: { type: 'string', enum: ['wav', 'ogg'] },
-      },
-      required: ['directory', 'autoCreateDirectory', 'namingStrategy', 'format'],
-    },
-  },
-  // Migration: ensure recording.format exists (default to 'wav') for pre-OGG configs
-  migrations: {
-    '>=0.0.0': (store) => {
-      try {
-        const rec = store.get('recording') as Partial<RecordingConfig> | undefined;
-        if (!rec || typeof rec !== 'object') {
-          store.set('recording', defaultRecordingConfig);
-        } else if (rec.format !== 'wav' && rec.format !== 'ogg') {
-          // Add default format while preserving other fields
-          store.set('recording', { ...defaultRecordingConfig, ...rec, format: 'wav' });
-        }
-      } catch {
-        // If store is unreadable, reset to defaults
-        store.set('recording', defaultRecordingConfig);
-      }
-    },
-  },
-});
-const store: AppStore = storeRaw as unknown as AppStore;
+const settingsStore = createAppSettingsStore(defaultRecordingConfig);
 
 let mainWindow: BrowserWindow | null = null;
 let preferencesWindow: BrowserWindow | null = null;
@@ -203,6 +135,10 @@ let deckBLoopBeats: number | null = null;
 let lastOSCTempo: number | null = null;
 let lastOSCDeckATrackId: string | null = null;
 let lastOSCDeckBTrackId: string | null = null;
+const ipcHost = createElectronIpcHost({
+  ipcMain,
+  getMainWindow: () => mainWindow,
+});
 let recordingStatus: RecordingStatus = { state: 'idle' };
 let deckATrackId: string | null = null;
 let deckBTrackId: string | null = null;
@@ -488,26 +424,6 @@ const pushNativeUiState = () => {
   pushNativeDeckMarkers();
 };
 
-const sendToRenderer = (channel: string, ...args: unknown[]) => {
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    return;
-  }
-  const webContents = mainWindow.webContents;
-  if (!webContents || webContents.isDestroyed()) {
-    return;
-  }
-  try {
-    if (webContents.getURL()) {
-      webContents.send(channel, ...args);
-    }
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('Render frame was disposed')) {
-      return;
-    }
-    console.error(`Error sending to renderer (${channel}):`, error);
-  }
-};
-
 const getNativeUI = (): NativeUIModule | null => {
   if (process.platform !== 'darwin') {
     return null;
@@ -559,7 +475,7 @@ const withNativeUI = <T>(fn: (native: NativeUIModule) => T, fallback: T): T => {
 
 const createWindow = () => { 
   // Create the browser window
-  mainWindow = new BrowserWindow({
+  mainWindow = shellHost.createBrowserWindow({
     width: 1100,
     height: 540,
     minWidth: 980,
@@ -587,13 +503,13 @@ const createWindow = () => {
   });
 
   // Create application menu
-  const isMac = process.platform === 'darwin';
+  const isMac = shellHost.platform === 'darwin';
   const template: Electron.MenuItemConstructorOptions[] = [];
   const SEP: Electron.MenuItemConstructorOptions = { type: 'separator' };
 
   if (isMac) {
     template.push({
-      label: app.name,
+      label: shellHost.appName,
       submenu: [
         {
           label: 'Preferences...',
@@ -645,8 +561,8 @@ const createWindow = () => {
     ],
   });
 
-  const menu = Menu.buildFromTemplate(template);
-  Menu.setApplicationMenu(menu);
+  const menu = shellHost.buildMenuFromTemplate(template);
+  shellHost.setApplicationMenu(menu);
 
   // Load the index.html of the app
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
@@ -671,7 +587,7 @@ const createPreferencesWindow = () => {
     return;
   }
 
-  preferencesWindow = new BrowserWindow({
+  preferencesWindow = shellHost.createBrowserWindow({
     parent: mainWindow,
     modal: true,
     width: 520,
@@ -970,13 +886,13 @@ async function initializeCore() {
     },
   );
 
-  applyAudioConfig(store.get('audio'));
-  updateOSCConfig(store.get('osc'));
+  applyAudioConfig(settingsStore.getAudioConfig());
+  updateOSCConfig(settingsStore.getOscConfig());
 }
 
 function setRecordingStatus(next: RecordingStatus) {
   recordingStatus = next;
-  sendToRenderer('recording-status', recordingStatus);
+  ipcHost.send(IPC_EVENTS.recordingStatus, recordingStatus);
 }
 
 async function ensureRecordingDirectory(config: RecordingConfig) {
@@ -1072,12 +988,12 @@ async function prepareRecordingFile(config: RecordingConfig, format: 'wav' | 'og
 }
 
 // IPC Handlers
-ipcMain.handle('audio:load-track', async (_event, track, deck) => {
+ipcHost.handle(IPC_CHANNELS.audio.loadTrack, async (track, deck) => {
   await initializeCore();
   await loadTrackToDeck(track, deck);
 });
 
-ipcMain.handle('audio:play', async (_event, track, crossfade, targetDeck) => {
+ipcHost.handle(IPC_CHANNELS.audio.play, async (track, crossfade, targetDeck) => {
   await initializeCore();
   if (!audioEngine) {
     throw new Error('AudioEngine not initialized');
@@ -1094,12 +1010,12 @@ ipcMain.handle('audio:play', async (_event, track, crossfade, targetDeck) => {
   audioEngine.play(deck);
 });
 
-ipcMain.handle('audio:stop', async (_event, deck) => {
+ipcHost.handle(IPC_CHANNELS.audio.stop, async (deck) => {
   await initializeCore();
   audioEngine?.stop(deck);
 });
 
-ipcMain.handle('audio:get-state', async () => {
+ipcHost.handle(IPC_CHANNELS.audio.getState, async () => {
   await initializeCore();
   if (!audioEngine) {
     return cachedAudioState;
@@ -1109,42 +1025,42 @@ ipcMain.handle('audio:get-state', async () => {
   return state;
 });
 
-ipcMain.handle('audio:seek', async (_event, deck, position) => {
+ipcHost.handle(IPC_CHANNELS.audio.seek, async (deck, position) => {
   await initializeCore();
   audioEngine?.seek(deck, position);
 });
 
-ipcMain.handle('audio:set-crossfader', async (_event, position) => {
+ipcHost.handle(IPC_CHANNELS.audio.setCrossfader, async (position) => {
   await initializeCore();
   audioEngine?.setCrossfaderPosition(position);
 });
 
-ipcMain.handle('audio:set-master-tempo', async (_event, bpm) => {
+ipcHost.handle(IPC_CHANNELS.audio.setMasterTempo, async (bpm) => {
   await initializeCore();
   audioEngine?.setMasterTempo(bpm);
 });
 
-ipcMain.handle('audio:set-deck-cue', async (_event, deck, enabled) => {
+ipcHost.handle(IPC_CHANNELS.audio.setDeckCue, async (deck, enabled) => {
   await initializeCore();
   audioEngine?.setDeckCueEnabled(deck, enabled);
 });
 
-ipcMain.handle('audio:set-eq-cut', async (_event, deck, band, enabled) => {
+ipcHost.handle(IPC_CHANNELS.audio.setEqCut, async (deck, band, enabled) => {
   await initializeCore();
   audioEngine?.setEqCut(deck, band, enabled);
 });
 
-ipcMain.handle('audio:set-deck-gain', async (_event, deck, gain) => {
+ipcHost.handle(IPC_CHANNELS.audio.setDeckGain, async (deck, gain) => {
   await initializeCore();
   audioEngine?.setDeckGain(deck, gain);
 });
 
-ipcMain.handle('audio:set-beat-loop', async (_event, deck: 1 | 2, beats: number, masterTempo: number, currentPosition: number, beatGrid?: number[]) => {
+ipcHost.handle(IPC_CHANNELS.audio.setBeatLoop, async (deck: 1 | 2, beats: number, masterTempo: number, currentPosition: number, beatGrid?: number[]) => {
   await initializeCore();
   setBeatLoop(deck, beats, masterTempo, currentPosition, beatGrid);
 });
 
-ipcMain.handle('audio:clear-loop', async (_event, deck: 1 | 2) => {
+ipcHost.handle(IPC_CHANNELS.audio.clearLoop, async (deck: 1 | 2) => {
   await initializeCore();
   audioEngine?.clearLoop(deck);
   if (deck === 1) {
@@ -1154,28 +1070,28 @@ ipcMain.handle('audio:clear-loop', async (_event, deck: 1 | 2) => {
   }
 });
 
-ipcMain.handle('audio:start-deck', async (_event, deck) => {
+ipcHost.handle(IPC_CHANNELS.audio.startDeck, async (deck) => {
   await initializeCore();
   audioEngine?.play(deck);
 });
 
-ipcMain.handle('audio:set-mic-enabled', async (_event, enabled) => {
+ipcHost.handle(IPC_CHANNELS.audio.setMicEnabled, async (enabled) => {
   await initializeCore();
   audioEngine?.setMicEnabled(enabled);
 });
 
 // Audio device/config handlers
-ipcMain.handle('audio:get-devices', async () => {
+ipcHost.handle(IPC_CHANNELS.audio.getDevices, async () => {
   const mod = await ensureAudioModule();
   return mod.listAudioDevices().filter((d) => (d.maxOutputChannels ?? 0) > 0);
 });
 
-ipcMain.handle('audio:get-config', () => {
-  return store.get('audio');
+ipcHost.handle(IPC_CHANNELS.audio.getConfig, () => {
+  return settingsStore.getAudioConfig();
 });
 
-ipcMain.handle('audio:update-config', async (_event, config: AudioConfig) => {
-  store.set('audio', config);
+ipcHost.handle(IPC_CHANNELS.audio.updateConfig, async (config: AudioConfig) => {
+  settingsStore.setAudioConfig(config);
   await initializeCore();
   try {
     applyAudioConfig(config);
@@ -1185,25 +1101,25 @@ ipcMain.handle('audio:update-config', async (_event, config: AudioConfig) => {
 });
 
 // Recording config/state handlers
-ipcMain.handle('recording:get-config', () => {
-  return store.get('recording');
+ipcHost.handle(IPC_CHANNELS.recording.getConfig, () => {
+  return settingsStore.getRecordingConfig();
 });
 
-ipcMain.handle('recording:update-config', (_event, config: RecordingConfig) => {
-  store.set('recording', config);
-  return store.get('recording');
+ipcHost.handle(IPC_CHANNELS.recording.updateConfig, (config: RecordingConfig) => {
+  settingsStore.setRecordingConfig(config);
+  return settingsStore.getRecordingConfig();
 });
 
-ipcMain.handle('recording:get-status', () => {
+ipcHost.handle(IPC_CHANNELS.recording.getStatus, () => {
   return recordingStatus;
 });
 
-ipcMain.handle('recording:start', async (_event, format: 'wav' | 'ogg') => {
+ipcHost.handle(IPC_CHANNELS.recording.start, async (format: 'wav' | 'ogg') => {
   if (recordingStatus.state === 'recording' || recordingStatus.state === 'preparing') {
     return recordingStatus;
   }
 
-  const config = store.get('recording');
+  const config = settingsStore.getRecordingConfig();
   try {
     await ensureRecordingDirectory(config);
   } catch (error) {
@@ -1230,7 +1146,7 @@ ipcMain.handle('recording:start', async (_event, format: 'wav' | 'ogg') => {
   return recordingStatus;
 });
 
-ipcMain.handle('recording:stop', async () => {
+ipcHost.handle(IPC_CHANNELS.recording.stop, async () => {
   if (recordingStatus.state !== 'recording' && recordingStatus.state !== 'preparing' && recordingStatus.state !== 'stopping') {
     return recordingStatus;
   }
@@ -1338,7 +1254,7 @@ const stopNativeUIPolling = () => {
   }
 };
 
-ipcMain.handle('native-ui:attach', async (_event, frame: NativeUIFrame) => {
+ipcHost.handle(IPC_CHANNELS.nativeUi.attach, async (frame: NativeUIFrame) => {
   const win = mainWindow;
   if (!win || win.isDestroyed()) {
     return false;
@@ -1357,7 +1273,7 @@ ipcMain.handle('native-ui:attach', async (_event, frame: NativeUIFrame) => {
   }, false);
 });
 
-ipcMain.handle('native-ui:set-frame', async (_event, frame: NativeUIFrame) => {
+ipcHost.handle(IPC_CHANNELS.nativeUi.setFrame, async (frame: NativeUIFrame) => {
   const next = sanitizeNativeUIFrame(frame);
   if (next.width <= 0 || next.height <= 0) {
     return false;
@@ -1368,41 +1284,14 @@ ipcMain.handle('native-ui:set-frame', async (_event, frame: NativeUIFrame) => {
   }, false);
 });
 
-ipcMain.handle('native-ui:set-waveform', async (_event, deck: 1 | 2, samples: number[]) => {
+ipcHost.handle(IPC_CHANNELS.nativeUi.setWaveform, async (deck: 1 | 2, samples: number[]) => {
   return withNativeUI((native) => {
     native.setWaveform(deck, samples);
     return true;
   }, false);
 });
 
-ipcMain.handle('native-ui:set-progress', async (_event, deck: 1 | 2, positionFrames: number, totalFrames: number, audioSampleRate: number) => {
-  return withNativeUI((native) => {
-    if (typeof native.setDeckProgress === 'function') {
-      native.setDeckProgress(deck, positionFrames, totalFrames, audioSampleRate);
-    }
-    return true;
-  }, false);
-});
-
-ipcMain.handle('native-ui:set-markers', async (_event, deck: 1 | 2, beats: number[], intro: number | null, outro: number | null) => {
-  return withNativeUI((native) => {
-    if (typeof native.setDeckMarkers === 'function') {
-      native.setDeckMarkers(deck, beats, intro, outro);
-    }
-    return true;
-  }, false);
-});
-
-ipcMain.handle('native-ui:set-console-state', async (_event, state: NativeConsoleState) => {
-  return withNativeUI((native) => {
-    if (typeof native.setConsoleState === 'function') {
-      native.setConsoleState(state);
-    }
-    return true;
-  }, false);
-});
-
-ipcMain.handle('native-ui:detach', async () => {
+ipcHost.handle(IPC_CHANNELS.nativeUi.detach, async () => {
   return withNativeUI((native) => {
     stopNativeUIPolling();
     native.detach();
@@ -1410,7 +1299,7 @@ ipcMain.handle('native-ui:detach', async () => {
   }, false);
 });
 
-ipcMain.handle('native-ui:set-artwork', async (_event, deck: 1 | 2, width: number, height: number, rgba: Buffer) => {
+ipcHost.handle(IPC_CHANNELS.nativeUi.setArtwork, async (deck: 1 | 2, width: number, height: number, rgba: Buffer) => {
   return withNativeUI((native) => {
     if (typeof native.setDeckArtwork === 'function') {
       native.setDeckArtwork(deck, width, height, rgba);
@@ -1419,7 +1308,7 @@ ipcMain.handle('native-ui:set-artwork', async (_event, deck: 1 | 2, width: numbe
   }, false);
 });
 
-ipcMain.handle('native-ui:clear-artwork', async (_event, deck: 1 | 2) => {
+ipcHost.handle(IPC_CHANNELS.nativeUi.clearArtwork, async (deck: 1 | 2) => {
   return withNativeUI((native) => {
     if (typeof native.clearDeckArtwork === 'function') {
       native.clearDeckArtwork(deck);
@@ -1429,8 +1318,8 @@ ipcMain.handle('native-ui:clear-artwork', async (_event, deck: 1 | 2) => {
 });
 
 // System info
-ipcMain.handle('system:get-info', () => {
-  const metrics = app.getAppMetrics();
+ipcHost.handle(IPC_CHANNELS.system.getInfo, () => {
+  const metrics = shellHost.getAppMetrics();
   
   // Sum CPU usage across all processes
   const totalCpuPercent = metrics.reduce((sum, metric) => {
@@ -1448,24 +1337,25 @@ ipcMain.handle('system:get-info', () => {
 });
 
 // OSC config handlers
-ipcMain.handle('osc:get-config', () => {
-  return store.get('osc');
+ipcHost.handle(IPC_CHANNELS.osc.getConfig, () => {
+  return settingsStore.getOscConfig();
 });
 
-ipcMain.handle('osc:update-config', async (_event, config: OSCConfig) => {
-  store.set('osc', config);
+ipcHost.handle(IPC_CHANNELS.osc.updateConfig, async (config: OSCConfig) => {
+  settingsStore.setOscConfig(config);
   updateOSCConfig(config);
 });
 
 
 // App lifecycle
-app.on('ready', async () => {
+registerRuntimeLifecycle(shellHost, {
+  onReady: async () => {
   await initializeCore();
 
   createWindow();
-});
+  },
 
-app.on('window-all-closed', async () => {
+  onWindowAllClosed: async () => {
   if (audioEngine) {
     try {
       audioEngine.close();
@@ -1475,27 +1365,28 @@ app.on('window-all-closed', async () => {
     audioEngine = null;
   }
 
-  if (process.platform !== 'darwin') {
-    app.quit();
+  if (shellHost.platform !== 'darwin') {
+    shellHost.quit();
   }
-});
+  },
 
-app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
-  }
-});
+  onActivate: () => {
+    if (shellHost.shouldOpenMainWindow()) {
+      createWindow();
+    }
+  },
 
 // Ensure recording is finalized on explicit app quit (e.g., Cmd+Q on macOS)
-app.on('before-quit', async () => {
-  try {
-    if (recordingStatus.state === 'recording' || recordingStatus.state === 'preparing' || recordingStatus.state === 'stopping') {
-      audioEngine?.stopRecording();
-      setRecordingStatus({ state: 'idle', activeFile: undefined, lastError: undefined });
+  onBeforeQuit: async () => {
+    try {
+      if (recordingStatus.state === 'recording' || recordingStatus.state === 'preparing' || recordingStatus.state === 'stopping') {
+        audioEngine?.stopRecording();
+        setRecordingStatus({ state: 'idle', activeFile: undefined, lastError: undefined });
+      }
+    } catch (err) {
+      console.error('[Recording] Failed to stop during before-quit:', err);
     }
-  } catch (err) {
-    console.error('[Recording] Failed to stop during before-quit:', err);
-  }
+  },
 });
 
 // In this file you can include the rest of your app's specific main process

--- a/app/src/main/host/electron-ipc-host.ts
+++ b/app/src/main/host/electron-ipc-host.ts
@@ -1,0 +1,41 @@
+import type { BrowserWindow, IpcMain } from 'electron';
+
+export interface IpcHost {
+  handle<Args extends unknown[]>(channel: string, handler: (...args: Args) => unknown): void;
+  send(channel: string, ...args: unknown[]): void;
+}
+
+export function createElectronIpcHost(deps: {
+  ipcMain: IpcMain;
+  getMainWindow: () => BrowserWindow | null;
+}): IpcHost {
+  const { ipcMain, getMainWindow } = deps;
+
+  return {
+    handle<Args extends unknown[]>(channel: string, handler: (...args: Args) => unknown) {
+      ipcMain.handle(channel, (_event, ...args: unknown[]) => handler(...(args as Args)));
+    },
+    send(channel, ...args) {
+      const mainWindow = getMainWindow();
+      if (!mainWindow || mainWindow.isDestroyed()) {
+        return;
+      }
+
+      const webContents = mainWindow.webContents;
+      if (!webContents || webContents.isDestroyed()) {
+        return;
+      }
+
+      try {
+        if (webContents.getURL()) {
+          webContents.send(channel, ...args);
+        }
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('Render frame was disposed')) {
+          return;
+        }
+        console.error(`[ipc-host] failed to send ${channel}:`, error);
+      }
+    },
+  };
+}

--- a/app/src/main/host/shell-host.ts
+++ b/app/src/main/host/shell-host.ts
@@ -1,0 +1,81 @@
+import type { App, BrowserWindowConstructorOptions, BaseWindow, BrowserWindow as ElectronBrowserWindow, Menu as ElectronMenu, MenuItemConstructorOptions } from 'electron';
+
+type BrowserWindowCtor = {
+  new (options?: BrowserWindowConstructorOptions): ElectronBrowserWindow;
+  getAllWindows(): BaseWindow[];
+};
+
+type MenuApi = {
+  buildFromTemplate(template: MenuItemConstructorOptions[]): ElectronMenu;
+  setApplicationMenu(menu: ElectronMenu | null): void;
+};
+
+export type ShellPathKey = 'music';
+
+export interface ShellHost {
+  readonly appName: string;
+  readonly platform: NodeJS.Platform;
+  getPath(name: ShellPathKey): string;
+  quit(): void;
+  onReady(listener: () => void | Promise<void>): void;
+  onWindowAllClosed(listener: () => void | Promise<void>): void;
+  onActivate(listener: () => void | Promise<void>): void;
+  onBeforeQuit(listener: () => void | Promise<void>): void;
+  shouldOpenMainWindow(): boolean;
+  createBrowserWindow(options: BrowserWindowConstructorOptions): ElectronBrowserWindow;
+  buildMenuFromTemplate(template: MenuItemConstructorOptions[]): ElectronMenu;
+  setApplicationMenu(menu: ElectronMenu | null): void;
+  getAppMetrics(): ReturnType<App['getAppMetrics']>;
+}
+
+export function createElectronShellHost(deps: {
+  app: App;
+  BrowserWindow: BrowserWindowCtor;
+  Menu: MenuApi;
+}): ShellHost {
+  const { app, BrowserWindow, Menu } = deps;
+
+  return {
+    get appName() {
+      return app.name;
+    },
+    get platform() {
+      return process.platform;
+    },
+    getPath(name) {
+      return app.getPath(name);
+    },
+    quit() {
+      app.quit();
+    },
+    onReady(listener) {
+      app.whenReady().then(listener).catch((error) => {
+        console.error('[ShellHost] ready hook failed', error);
+      });
+    },
+    onWindowAllClosed(listener) {
+      app.on('window-all-closed', listener);
+    },
+    onActivate(listener) {
+      app.on('activate', listener);
+    },
+    onBeforeQuit(listener) {
+      app.on('before-quit', listener);
+    },
+    shouldOpenMainWindow() {
+      return BrowserWindow.getAllWindows().length === 0;
+    },
+    createBrowserWindow(options) {
+      return new BrowserWindow(options);
+    },
+    buildMenuFromTemplate(template) {
+      return Menu.buildFromTemplate(template);
+    },
+    setApplicationMenu(menu) {
+      Menu.setApplicationMenu(menu);
+    },
+    getAppMetrics() {
+      return app.getAppMetrics();
+    },
+  };
+}

--- a/app/src/main/ipc-contract.ts
+++ b/app/src/main/ipc-contract.ts
@@ -1,0 +1,52 @@
+export const IPC_CHANNELS = {
+  audio: {
+    loadTrack: 'audio:load-track',
+    play: 'audio:play',
+    stop: 'audio:stop',
+    getState: 'audio:get-state',
+    seek: 'audio:seek',
+    setCrossfader: 'audio:set-crossfader',
+    setMasterTempo: 'audio:set-master-tempo',
+    setDeckCue: 'audio:set-deck-cue',
+    setEqCut: 'audio:set-eq-cut',
+    setDeckGain: 'audio:set-deck-gain',
+    setBeatLoop: 'audio:set-beat-loop',
+    clearLoop: 'audio:clear-loop',
+    startDeck: 'audio:start-deck',
+    setMicEnabled: 'audio:set-mic-enabled',
+    getDevices: 'audio:get-devices',
+    getConfig: 'audio:get-config',
+    updateConfig: 'audio:update-config',
+  },
+  recording: {
+    getConfig: 'recording:get-config',
+    updateConfig: 'recording:update-config',
+    getStatus: 'recording:get-status',
+    start: 'recording:start',
+    stop: 'recording:stop',
+  },
+  nativeUi: {
+    attach: 'native-ui:attach',
+    setFrame: 'native-ui:set-frame',
+    setWaveform: 'native-ui:set-waveform',
+    detach: 'native-ui:detach',
+    setArtwork: 'native-ui:set-artwork',
+    clearArtwork: 'native-ui:clear-artwork',
+  },
+  system: {
+    getInfo: 'system:get-info',
+  },
+  osc: {
+    getConfig: 'osc:get-config',
+    updateConfig: 'osc:update-config',
+  },
+} as const;
+
+export const IPC_EVENTS = {
+  notification: 'notification',
+  trackEnded: 'track-ended',
+  waveformChunk: 'waveform-chunk',
+  waveformComplete: 'waveform-complete',
+  trackStructure: 'track-structure',
+  recordingStatus: 'recording-status',
+} as const;

--- a/app/src/main/runtime/lifecycle-bootstrap.ts
+++ b/app/src/main/runtime/lifecycle-bootstrap.ts
@@ -1,0 +1,15 @@
+import type { ShellHost } from '../host/shell-host';
+
+export interface RuntimeLifecycleHooks {
+  onReady: () => void | Promise<void>;
+  onWindowAllClosed: () => void | Promise<void>;
+  onActivate: () => void | Promise<void>;
+  onBeforeQuit: () => void | Promise<void>;
+}
+
+export function registerRuntimeLifecycle(host: ShellHost, hooks: RuntimeLifecycleHooks) {
+  host.onReady(hooks.onReady);
+  host.onWindowAllClosed(hooks.onWindowAllClosed);
+  host.onActivate(hooks.onActivate);
+  host.onBeforeQuit(hooks.onBeforeQuit);
+}

--- a/app/src/main/settings/app-settings-store.ts
+++ b/app/src/main/settings/app-settings-store.ts
@@ -1,0 +1,110 @@
+import Store from 'electron-store';
+import type { AudioConfig, OSCConfig, RecordingConfig } from '../../types';
+
+interface AppStoreSchema {
+  osc: OSCConfig;
+  audio: AudioConfig;
+  recording: RecordingConfig;
+}
+
+interface AppStore {
+  get(key: 'osc'): OSCConfig;
+  get(key: 'audio'): AudioConfig;
+  get(key: 'recording'): RecordingConfig;
+  set(key: 'osc', value: OSCConfig): void;
+  set(key: 'audio', value: AudioConfig): void;
+  set(key: 'recording', value: RecordingConfig): void;
+}
+
+export interface AppSettingsStore {
+  getOscConfig(): OSCConfig;
+  setOscConfig(config: OSCConfig): void;
+  getAudioConfig(): AudioConfig;
+  setAudioConfig(config: AudioConfig): void;
+  getRecordingConfig(): RecordingConfig;
+  setRecordingConfig(config: RecordingConfig): void;
+}
+
+export function createAppSettingsStore(defaultRecordingConfig: RecordingConfig): AppSettingsStore {
+  const raw = new Store<AppStoreSchema>({
+    defaults: {
+      osc: {
+        enabled: false,
+        host: '127.0.0.1',
+        port: 9000,
+      },
+      audio: {
+        mainChannels: [0, 1],
+        cueChannels: [null, null],
+      },
+      recording: defaultRecordingConfig,
+    },
+    schema: {
+      osc: {
+        type: 'object',
+        properties: {
+          enabled: { type: 'boolean' },
+          host: { type: 'string' },
+          port: { type: 'number', minimum: 1, maximum: 65535 },
+        },
+        required: ['enabled', 'host', 'port'],
+      },
+      audio: {
+        type: 'object',
+        properties: {
+          deviceId: { type: ['string', 'null'] },
+          mainChannels: { type: 'array', items: { type: ['number', 'null'] }, minItems: 2, maxItems: 2 },
+          cueChannels: { type: 'array', items: { type: ['number', 'null'] }, minItems: 2, maxItems: 2 },
+        },
+        required: ['mainChannels', 'cueChannels'],
+      },
+      recording: {
+        type: 'object',
+        properties: {
+          directory: { type: 'string' },
+          autoCreateDirectory: { type: 'boolean' },
+          namingStrategy: { type: 'string', enum: ['timestamp', 'sequential'] },
+          format: { type: 'string', enum: ['wav', 'ogg'] },
+        },
+        required: ['directory', 'autoCreateDirectory', 'namingStrategy', 'format'],
+      },
+    },
+    migrations: {
+      '>=0.0.0': (store) => {
+        try {
+          const rec = store.get('recording') as Partial<RecordingConfig> | undefined;
+          if (!rec || typeof rec !== 'object') {
+            store.set('recording', defaultRecordingConfig);
+          } else if (rec.format !== 'wav' && rec.format !== 'ogg') {
+            store.set('recording', { ...defaultRecordingConfig, ...rec, format: 'wav' });
+          }
+        } catch {
+          store.set('recording', defaultRecordingConfig);
+        }
+      },
+    },
+  });
+
+  const store = raw as unknown as AppStore;
+
+  return {
+    getOscConfig() {
+      return store.get('osc');
+    },
+    setOscConfig(config) {
+      store.set('osc', config);
+    },
+    getAudioConfig() {
+      return store.get('audio');
+    },
+    setAudioConfig(config) {
+      store.set('audio', config);
+    },
+    getRecordingConfig() {
+      return store.get('recording');
+    },
+    setRecordingConfig(config) {
+      store.set('recording', config);
+    },
+  };
+}

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -4,6 +4,7 @@
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
+import { IPC_CHANNELS, IPC_EVENTS } from './main/ipc-contract';
 import type {
   Track,
   OSCConfig,
@@ -25,53 +26,53 @@ type NativeUIFrame = {
 // the ipcRenderer without exposing the entire object
 contextBridge.exposeInMainWorld('electronAPI', {
   // Audio Engine
-  audioLoadTrack: (track: Track, deck: 1 | 2) => ipcRenderer.invoke('audio:load-track', track, deck),
-  audioPlay: (track: Track, crossfade: boolean, targetDeck?: 1 | 2 | null) => ipcRenderer.invoke('audio:play', track, crossfade, targetDeck ?? null),
-  audioStop: (deck: 1 | 2) => ipcRenderer.invoke('audio:stop', deck),
-  audioGetState: () => ipcRenderer.invoke('audio:get-state'),
-  audioSeek: (deck: 1 | 2, position: number) => ipcRenderer.invoke('audio:seek', deck, position),
-  audioSetCrossfader: (position: number) => ipcRenderer.invoke('audio:set-crossfader', position),
-  audioSetMasterTempo: (bpm: number) => ipcRenderer.invoke('audio:set-master-tempo', bpm),
-  audioSetDeckCue: (deck: 1 | 2, enabled: boolean) => ipcRenderer.invoke('audio:set-deck-cue', deck, enabled),
-  audioSetEqCut: (deck: 1 | 2, band: EqBand, enabled: boolean) => ipcRenderer.invoke('audio:set-eq-cut', deck, band, enabled),
-  audioSetDeckGain: (deck: 1 | 2, gain: number) => ipcRenderer.invoke('audio:set-deck-gain', deck, gain),
-  audioStartDeck: (deck: 1 | 2) => ipcRenderer.invoke('audio:start-deck', deck),
-  audioSetMicEnabled: (enabled: boolean) => ipcRenderer.invoke('audio:set-mic-enabled', enabled),
-  audioSetBeatLoop: (deck: 1 | 2, beats: number, masterTempo: number, currentPosition: number, beatGrid?: number[]) => ipcRenderer.invoke('audio:set-beat-loop', deck, beats, masterTempo, currentPosition, beatGrid),
-  audioClearLoop: (deck: 1 | 2) => ipcRenderer.invoke('audio:clear-loop', deck),
+  audioLoadTrack: (track: Track, deck: 1 | 2) => ipcRenderer.invoke(IPC_CHANNELS.audio.loadTrack, track, deck),
+  audioPlay: (track: Track, crossfade: boolean, targetDeck?: 1 | 2 | null) => ipcRenderer.invoke(IPC_CHANNELS.audio.play, track, crossfade, targetDeck ?? null),
+  audioStop: (deck: 1 | 2) => ipcRenderer.invoke(IPC_CHANNELS.audio.stop, deck),
+  audioGetState: () => ipcRenderer.invoke(IPC_CHANNELS.audio.getState),
+  audioSeek: (deck: 1 | 2, position: number) => ipcRenderer.invoke(IPC_CHANNELS.audio.seek, deck, position),
+  audioSetCrossfader: (position: number) => ipcRenderer.invoke(IPC_CHANNELS.audio.setCrossfader, position),
+  audioSetMasterTempo: (bpm: number) => ipcRenderer.invoke(IPC_CHANNELS.audio.setMasterTempo, bpm),
+  audioSetDeckCue: (deck: 1 | 2, enabled: boolean) => ipcRenderer.invoke(IPC_CHANNELS.audio.setDeckCue, deck, enabled),
+  audioSetEqCut: (deck: 1 | 2, band: EqBand, enabled: boolean) => ipcRenderer.invoke(IPC_CHANNELS.audio.setEqCut, deck, band, enabled),
+  audioSetDeckGain: (deck: 1 | 2, gain: number) => ipcRenderer.invoke(IPC_CHANNELS.audio.setDeckGain, deck, gain),
+  audioStartDeck: (deck: 1 | 2) => ipcRenderer.invoke(IPC_CHANNELS.audio.startDeck, deck),
+  audioSetMicEnabled: (enabled: boolean) => ipcRenderer.invoke(IPC_CHANNELS.audio.setMicEnabled, enabled),
+  audioSetBeatLoop: (deck: 1 | 2, beats: number, masterTempo: number, currentPosition: number, beatGrid?: number[]) => ipcRenderer.invoke(IPC_CHANNELS.audio.setBeatLoop, deck, beats, masterTempo, currentPosition, beatGrid),
+  audioClearLoop: (deck: 1 | 2) => ipcRenderer.invoke(IPC_CHANNELS.audio.clearLoop, deck),
   
   // Audio Config
-  audioGetDevices: () => ipcRenderer.invoke('audio:get-devices'),
-  audioGetConfig: () => ipcRenderer.invoke('audio:get-config'),
-  audioUpdateConfig: (config: AudioConfig) => ipcRenderer.invoke('audio:update-config', config),
+  audioGetDevices: () => ipcRenderer.invoke(IPC_CHANNELS.audio.getDevices),
+  audioGetConfig: () => ipcRenderer.invoke(IPC_CHANNELS.audio.getConfig),
+  audioUpdateConfig: (config: AudioConfig) => ipcRenderer.invoke(IPC_CHANNELS.audio.updateConfig, config),
 
   // System info
-  getSystemInfo: () => ipcRenderer.invoke('system:get-info'),
+  getSystemInfo: () => ipcRenderer.invoke(IPC_CHANNELS.system.getInfo),
 
   // OSC Config
-  oscGetConfig: () => ipcRenderer.invoke('osc:get-config'),
-  oscUpdateConfig: (config: OSCConfig) => ipcRenderer.invoke('osc:update-config', config),
+  oscGetConfig: () => ipcRenderer.invoke(IPC_CHANNELS.osc.getConfig),
+  oscUpdateConfig: (config: OSCConfig) => ipcRenderer.invoke(IPC_CHANNELS.osc.updateConfig, config),
 
   // Recording
-  recordingGetConfig: () => ipcRenderer.invoke('recording:get-config'),
-  recordingUpdateConfig: (config: RecordingConfig) => ipcRenderer.invoke('recording:update-config', config),
-  recordingGetStatus: () => ipcRenderer.invoke('recording:get-status'),
-  recordingStart: (format: 'wav' | 'ogg') => ipcRenderer.invoke('recording:start', format),
-  recordingStop: () => ipcRenderer.invoke('recording:stop'),
+  recordingGetConfig: () => ipcRenderer.invoke(IPC_CHANNELS.recording.getConfig),
+  recordingUpdateConfig: (config: RecordingConfig) => ipcRenderer.invoke(IPC_CHANNELS.recording.updateConfig, config),
+  recordingGetStatus: () => ipcRenderer.invoke(IPC_CHANNELS.recording.getStatus),
+  recordingStart: (format: 'wav' | 'ogg') => ipcRenderer.invoke(IPC_CHANNELS.recording.start, format),
+  recordingStop: () => ipcRenderer.invoke(IPC_CHANNELS.recording.stop),
 
   // Native UI
-  nativeUiAttach: (frame: NativeUIFrame) => ipcRenderer.invoke('native-ui:attach', frame),
-  nativeUiSetFrame: (frame: NativeUIFrame) => ipcRenderer.invoke('native-ui:set-frame', frame),
-  nativeUiSetWaveform: (deck: 1 | 2, samples: number[]) => ipcRenderer.invoke('native-ui:set-waveform', deck, samples),
-  nativeUiSetArtwork: (deck: 1 | 2, width: number, height: number, rgba: Uint8Array) => ipcRenderer.invoke('native-ui:set-artwork', deck, width, height, Buffer.from(rgba)),
-  nativeUiClearArtwork: (deck: 1 | 2) => ipcRenderer.invoke('native-ui:clear-artwork', deck),
-  nativeUiDetach: () => ipcRenderer.invoke('native-ui:detach'),
+  nativeUiAttach: (frame: NativeUIFrame) => ipcRenderer.invoke(IPC_CHANNELS.nativeUi.attach, frame),
+  nativeUiSetFrame: (frame: NativeUIFrame) => ipcRenderer.invoke(IPC_CHANNELS.nativeUi.setFrame, frame),
+  nativeUiSetWaveform: (deck: 1 | 2, samples: number[]) => ipcRenderer.invoke(IPC_CHANNELS.nativeUi.setWaveform, deck, samples),
+  nativeUiSetArtwork: (deck: 1 | 2, width: number, height: number, rgba: Uint8Array) => ipcRenderer.invoke(IPC_CHANNELS.nativeUi.setArtwork, deck, width, height, Buffer.from(rgba)),
+  nativeUiClearArtwork: (deck: 1 | 2) => ipcRenderer.invoke(IPC_CHANNELS.nativeUi.clearArtwork, deck),
+  nativeUiDetach: () => ipcRenderer.invoke(IPC_CHANNELS.nativeUi.detach),
 
   // Event listeners - return cleanup functions
   onNotification: (callback: (message: string) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, message: string) => callback(message);
-    ipcRenderer.on('notification', listener);
-    return () => ipcRenderer.removeListener('notification', listener);
+    ipcRenderer.on(IPC_EVENTS.notification, listener);
+    return () => ipcRenderer.removeListener(IPC_EVENTS.notification, listener);
   },
 
   onWaveformLoaded: (callback: (data: { deck: 1 | 2; trackId: string; waveformData: Float32Array | number[] }) => void) => {
@@ -82,26 +83,26 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   onWaveformChunk: (callback: (data: { trackId: string; chunkIndex: number; totalChunks: number; chunk: number[] }) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, data: { trackId: string; chunkIndex: number; totalChunks: number; chunk: number[] }) => callback(data);
-    ipcRenderer.on('waveform-chunk', listener);
-    return () => ipcRenderer.removeListener('waveform-chunk', listener);
+    ipcRenderer.on(IPC_EVENTS.waveformChunk, listener);
+    return () => ipcRenderer.removeListener(IPC_EVENTS.waveformChunk, listener);
   },
 
   onWaveformComplete: (callback: (data: { trackId: string; totalFrames: number }) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, data: { trackId: string; totalFrames: number }) => callback(data);
-    ipcRenderer.on('waveform-complete', listener);
-    return () => ipcRenderer.removeListener('waveform-complete', listener);
+    ipcRenderer.on(IPC_EVENTS.waveformComplete, listener);
+    return () => ipcRenderer.removeListener(IPC_EVENTS.waveformComplete, listener);
   },
 
   onTrackStructure: (callback: (data: { trackId: string; deck: 1 | 2; structure: TrackStructure }) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, data: { trackId: string; deck: 1 | 2; structure: TrackStructure }) => callback(data);
-    ipcRenderer.on('track-structure', listener);
-    return () => ipcRenderer.removeListener('track-structure', listener);
+    ipcRenderer.on(IPC_EVENTS.trackStructure, listener);
+    return () => ipcRenderer.removeListener(IPC_EVENTS.trackStructure, listener);
   },
 
   onRecordingStatus: (callback: (status: RecordingStatus) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, status: RecordingStatus) => callback(status);
-    ipcRenderer.on('recording-status', listener);
-    return () => ipcRenderer.removeListener('recording-status', listener);
+    ipcRenderer.on(IPC_EVENTS.recordingStatus, listener);
+    return () => ipcRenderer.removeListener(IPC_EVENTS.recordingStatus, listener);
   },
 
 });

--- a/docs/phase4-shell-boundaries.md
+++ b/docs/phase4-shell-boundaries.md
@@ -1,0 +1,62 @@
+# Phase 4: Electron shell decoupling boundaries
+
+This document captures the host-neutral boundaries introduced in issue #26.
+
+## Host abstraction boundary
+
+The app shell lifecycle is now routed through a host interface in `app/src/main/host/shell-host.ts`.
+
+Current Electron adapter responsibilities:
+- Resolve platform and app metadata (`platform`, `appName`)
+- Resolve host paths (`music`)
+- Register lifecycle hooks (`ready`, `window-all-closed`, `activate`, `before-quit`)
+- Create windows and own menu construction bridge
+- Query process metrics for system info
+
+Future Rust host mapping:
+- `onReady` -> Rust runtime bootstrap callback
+- `createBrowserWindow` -> Rust host window constructor (winit/tao/egui shell)
+- `buildMenuFromTemplate` / `setApplicationMenu` -> host-native menu model
+- `shouldOpenMainWindow` -> host window registry query
+- `getAppMetrics` -> Rust runtime metrics source
+
+Lifecycle hook wiring is now centralized in `app/src/main/runtime/lifecycle-bootstrap.ts`.
+
+## Settings persistence boundary
+
+`electron-store` is now isolated in `app/src/main/settings/app-settings-store.ts`.
+Feature code reads/writes through the `AppSettingsStore` interface only.
+
+Current settings ports:
+- `getAudioConfig` / `setAudioConfig`
+- `getOscConfig` / `setOscConfig`
+- `getRecordingConfig` / `setRecordingConfig`
+
+Future Rust host mapping:
+- Implement the same interface on top of a Rust-backed config store (TOML/JSON/SQLite)
+- Keep renderer-facing IPC unchanged while swapping backend persistence
+
+## IPC contract boundary
+
+IPC channel names are centralized in `app/src/main/ipc-contract.ts` and consumed by both `main.ts` and `preload.ts`.
+
+This avoids string drift and makes host replacement simpler because the contract surface is explicit and auditable.
+
+Main-process IPC registration and renderer event delivery are routed through `app/src/main/host/electron-ipc-host.ts` (`IpcHost`).
+This confines direct `ipcMain` usage to an adapter module, which allows swapping to a Rust-host bridge with the same runtime-facing shape.
+
+## IPC surface reduction in this phase
+
+Removed main-process handlers that were not used by the current renderer bridge:
+- `native-ui:set-progress`
+- `native-ui:set-markers`
+- `native-ui:set-console-state`
+
+Native deck progress/markers/console synchronization remains internal to the main process via direct native module calls.
+
+## Behavioral compatibility
+
+No user-facing behavior change is intended in this phase.
+- Existing preload API shape is preserved
+- Existing recording/audio/OSC/native-ui workflows continue through the same renderer methods
+- Lifecycle behavior remains equivalent with host adapter indirection


### PR DESCRIPTION
## Summary
Implement Issue #26 (Phase 4) by isolating Electron-specific lifecycle/IPC/settings concerns behind host-facing boundaries while preserving current product behavior.

## What changed
- Added shell host abstraction and moved app/window lifecycle wiring behind it
- Added IPC host adapter and routed main-process handlers/events through it
- Centralized IPC channels/events into a shared contract used by both main and preload
- Isolated settings persistence behind an app settings store interface
- Reduced unused IPC surface by removing unused native-ui handlers
- Added migration notes for Rust-native host mapping

## Files
- app/src/main.ts
- app/src/preload.ts
- app/src/main/host/shell-host.ts
- app/src/main/host/electron-ipc-host.ts
- app/src/main/ipc-contract.ts
- app/src/main/runtime/lifecycle-bootstrap.ts
- app/src/main/settings/app-settings-store.ts
- docs/phase4-shell-boundaries.md

## Validation
- npm run lint

Closes #26