### PR TITLE
Fix 4-channel Main/Cue routing in Rust audio backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5750,6 +5750,7 @@ dependencies = [
  "symphonia 0.5.5",
  "thiserror 1.0.69",
  "thread-priority",
+ "tracing",
  "vorbis_rs",
  "web-audio-api",
 ]

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -26,3 +26,4 @@ vorbis_rs = "0.5"
 
 # Audio encoding
 hound = "3.5"
+tracing = "0.1"

--- a/crates/audio/src/engine_backend.rs
+++ b/crates/audio/src/engine_backend.rs
@@ -16,6 +16,7 @@ use web_audio_api::media_devices::{enumerate_devices_sync, MediaDeviceInfoKind};
 use web_audio_api::media_streams::MediaStreamTrack;
 use web_audio_api::node::{
   AudioNode,
+  ChannelCountMode,
   BiquadFilterNode,
   BiquadFilterType,
   ChannelMergerNode,
@@ -400,13 +401,38 @@ struct WebAudioGraph {
 
 impl WebAudioGraph {
   fn new(io: &EngineIoConfig, sample_rate: f32) -> BackendResult<Self> {
-    let output_channels = io.output_channels.max(2) as usize;
+    let requested_output_channels = io.output_channels.max(2) as usize;
     let context = AudioContext::new(AudioContextOptions {
       sample_rate: Some(sample_rate),
       sink_id: resolve_sink_id(io.output_device_name.as_deref()),
       latency_hint: AudioContextLatencyCategory::Playback,
       ..AudioContextOptions::default()
     });
+
+    let destination = context.destination();
+    let destination_max_channels = destination.max_channel_count().max(2);
+    let output_channels = requested_output_channels.min(destination_max_channels);
+    destination.set_channel_count_mode(ChannelCountMode::Explicit);
+    destination.set_channel_count(output_channels);
+
+    let clamp_channels = |pair: [Option<u16>; 2]| -> [Option<u16>; 2] {
+      [
+        pair[0].filter(|ch| (*ch as usize) < output_channels),
+        pair[1].filter(|ch| (*ch as usize) < output_channels),
+      ]
+    };
+
+    let main_channels = clamp_channels(io.main_channels);
+    let cue_channels = clamp_channels(io.cue_channels);
+
+    tracing::debug!(
+      "[AudioEngine] WebAudio destination channels: requested={}, max={}, active={}, main={:?}, cue={:?}",
+      requested_output_channels,
+      destination_max_channels,
+      output_channels,
+      main_channels,
+      cue_channels,
+    );
 
     let (deck_a, deck_a_track) = BufferFeeder::new(2, sample_rate);
     let (deck_b, deck_b_track) = BufferFeeder::new(2, sample_rate);
@@ -439,8 +465,8 @@ impl WebAudioGraph {
 
     master_bus.connect(&main_splitter);
     cue_source.connect(&cue_splitter);
-    route_stereo_to_merger(&main_splitter, &main_merger, io.main_channels);
-    route_stereo_to_merger(&cue_splitter, &main_merger, io.cue_channels);
+    route_stereo_to_merger(&main_splitter, &main_merger, main_channels);
+    route_stereo_to_merger(&cue_splitter, &main_merger, cue_channels);
     main_merger.connect(&context.destination());
 
     Ok(Self {

--- a/crates/audio/src/engine_core.rs
+++ b/crates/audio/src/engine_core.rs
@@ -635,6 +635,13 @@ impl AudioEngineCore {
     let mut state = self.state.lock();
     if deck == 1 { state.channel_config.deck_a_cue = enabled; }
     else         { state.channel_config.deck_b_cue = enabled; }
+    tracing::debug!(
+      "[AudioEngineCore] Cue {}: deck_a={}, deck_b={}, cue_channels={:?}",
+      if enabled { "enabled" } else { "disabled" },
+      state.channel_config.deck_a_cue,
+      state.channel_config.deck_b_cue,
+      state.channel_config.cue_channels,
+    );
     Ok(())
   }
 
@@ -841,7 +848,11 @@ fn build_input_stream(
   match device.build_input_stream(
     &input_config.into(),
     move |data: &[f32], _| {
-      let mut state = state_for_input.lock();
+      // Avoid startup lock starvation when input callbacks are very frequent
+      // on some multi-channel interfaces (e.g. 4ch USB devices).
+      let Some(mut state) = state_for_input.try_lock() else {
+        return;
+      };
       let ch     = input_channels as usize;
       let frames = data.len() / ch;
       for frame in 0..frames {


### PR DESCRIPTION
## Summary
- Fix WebAudio routing so multi-channel output does not collapse into stereo.
- Explicitly set AudioDestinationNode to Explicit mode and set channel count to min(requested, max_channel_count).
- Clamp Main/Cue target channels to the active destination channel count.
- Keep diagnostic logs at debug level.

## Root Cause
The AudioContext destination could run effectively as stereo in some environments, which caused intended 4-channel routing to be folded into channels 1/2.

## Validation
- cargo check -p sujay_audio
- Runtime logs confirm: active=4, main=[2,3], cue=[0,1]
- Manual verification confirms: Main outputs on 3/4, Cue outputs on 1/2
